### PR TITLE
refactor: existing classifier moved to new module

### DIFF
--- a/src/services/file_classifiers/base.py
+++ b/src/services/file_classifiers/base.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+from werkzeug.datastructures import FileStorage
+
+
+class Base(ABC):
+    @staticmethod
+    @abstractmethod
+    def classify(file: FileStorage) -> str:
+        raise NotImplementedError

--- a/src/services/file_classifiers/classifier.py
+++ b/src/services/file_classifiers/classifier.py
@@ -1,0 +1,10 @@
+
+from werkzeug.datastructures import FileStorage
+
+from .heron_data.classifier import Classifier as HeronDataClassifier
+
+
+class Classifier:
+    @staticmethod
+    def classify(file: FileStorage) -> str:
+        return HeronDataClassifier().classify(file)

--- a/src/services/file_classifiers/heron_data/classifier.py
+++ b/src/services/file_classifiers/heron_data/classifier.py
@@ -1,0 +1,21 @@
+from werkzeug.datastructures import FileStorage
+
+from src.services.file_classifiers.base import Base
+
+
+class Classifier(Base):
+    @staticmethod
+    def classify(file: FileStorage) -> str:
+        filename = file.filename.lower()
+        # file_bytes = file.read()
+
+        if "drivers_license" in filename:
+            return "drivers_license"
+
+        if "bank_statement" in filename:
+            return "bank_statement"
+
+        if "invoice" in filename:
+            return "invoice"
+
+        return "unknown file"

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, request, Response, jsonify
 
-from src.classifier import classify_file
+from src.services.file_classifiers.classifier import Classifier
 from src.web.validators.file_name import FileNameValidator
 
 app = Flask(__name__)
@@ -12,7 +12,8 @@ def classify_file_route() -> Response:
     if not file_name_validation.valid:
         return jsonify({"error": file_name_validation.error_message}), 400
 
-    file_class = classify_file(request.files["file"])
+    file_class = Classifier.classify(request.files["file"])
+
     return jsonify({"file_class": file_class}), 200
 
 

--- a/tests/integration/web/test_app.py
+++ b/tests/integration/web/test_app.py
@@ -24,12 +24,34 @@ def test_no_selected_file(client):
     assert response.status_code == 400
 
 
-def test_success(client, mocker):
-    mocker.patch("src.web.app.classify_file", return_value="test_class")
+def test_success_bank_statement(client):
+    data = {"file": (BytesIO(b"dummy content"), "alans bank_statement.pdf")}
 
-    data = {"file": (BytesIO(b"dummy content"), "file.pdf")}
     response = client.post(
         "/classify_file", data=data, content_type="multipart/form-data"
     )
+
     assert response.status_code == 200
-    assert response.get_json() == {"file_class": "test_class"}
+    assert response.get_json() == {"file_class": "bank_statement"}
+
+
+def test_success_drivers_license(client):
+    data = {"file": (BytesIO(b"dummy content"), "alans drivers_license.pdf")}
+
+    response = client.post(
+        "/classify_file", data=data, content_type="multipart/form-data"
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"file_class": "drivers_license"}
+
+
+def test_success_invoice(client):
+    data = {"file": (BytesIO(b"dummy content"), "alans invoice.pdf")}
+
+    response = client.post(
+        "/classify_file", data=data, content_type="multipart/form-data"
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"file_class": "invoice"}


### PR DESCRIPTION
## What does this PR do?
refactor: existing classifier moved to new module


## Background context
- Moved existing classifier logic to a new module
- Created a base class for file classifiers
- Created a new classifier for heron data files
- Updated the app to use the new classifier

This is to allow the mulitple classifiers to be used in the future to speed up testing, without having to change the app code nor remove any existing classifiers.

We may want to use different classifiers for different file types, or even use multiple classifiers for the same file type to increase accuracy.
