### PR TITLE
fix: inconsistent license spelling

### DIFF
--- a/src/classifier.py
+++ b/src/classifier.py
@@ -6,7 +6,7 @@ def classify_file(file: FileStorage):
     # file_bytes = file.read()
 
     if "drivers_license" in filename:
-        return "drivers_licence"
+        return "drivers_license"
 
     if "bank_statement" in filename:
         return "bank_statement"


### PR DESCRIPTION
## What does this PR do?
fix: inconsistent license spelling


## Background context
Spelled drivers_license and drivers_licence...
Now they are both the USA spelling: drivers_license
